### PR TITLE
Fix deprecated creation of dynamic property Microsoft\Dynamics\Http\DynamicsResponse::$request

### DIFF
--- a/src/Dynamics/Http/DynamicsResponse.php
+++ b/src/Dynamics/Http/DynamicsResponse.php
@@ -28,6 +28,13 @@ namespace Microsoft\Dynamics\Http;
 class DynamicsResponse
 {
     /**
+    * The request
+    *
+    * @var object
+    */
+    private $request;
+    
+    /**
     * The body of the response
     *
     * @var string


### PR DESCRIPTION
DynamicsResponse is missing the variable $request which causes a php notice in PHP 8.2+
Thank you!